### PR TITLE
초기 설정 보완 및 소소한 Update(Employee DB 연동, 단위테스트 제약 기능 추가)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ moving-out(root)
 
 
 ## Docker로 Oracle DB 실행하기
+
+> #### 로컬에 Oracle Express 서버 환경이 설치가 되신 분이라면 이 단계를 건너 뛰어도 상관 없습니다.
+> * 설치 가이드(생활코딩-Oracle) : https://opentutorials.org/course/3885/26280
+
+___
+
 1. 각자 로컬 OS 환경에 맞는 Docker를 설치합니다.
     * windows10에서 Docker 설치하기 가이드 : https://www.lainyzine.com/ko/article/a-complete-guide-to-how-to-install-docker-desktop-on-windows-10/
 

--- a/moving-out-common/pom.xml
+++ b/moving-out-common/pom.xml
@@ -14,7 +14,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>moving-out-domain</name>
+    <name>moving-out-common</name>
     <description>moving-out-common</description>
 
     <properties>
@@ -47,15 +47,52 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <!-- 단위 테스트 실패 시, maven install에 제약을 거는 설정입니다.
+                    https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html
+                 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <testFailureIgnore>false</testFailureIgnore>
+                    <includes>
+                        <include>**/*Test*.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.3.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/MovingOutDomainApplication.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/MovingOutDomainApplication.java
@@ -1,15 +1,14 @@
-//package com.suwon.toy.moving.out.domain;
-//
-//import com.suwon.toy.moving.out.domain.configuration.DataSourceConfig;
-//import org.springframework.boot.SpringApplication;
-//import org.springframework.boot.autoconfigure.SpringBootApplication;
-//import org.springframework.boot.context.properties.EnableConfigurationProperties;
-//
-//@SpringBootApplication(scanBasePackages = "com.suwon.toy")
-//public class MovingOutDomainApplication {
-//
-//    public static void main(String[] args) {
-//        SpringApplication.run(MovingOutDomainApplication.class, args);
-//    }
-//
-//}
+package com.suwon.toy.moving.out.common;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MovingOutDomainApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MovingOutDomainApplication.class, args);
+    }
+
+}

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/configuration/MovingOutCommonConfig.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/configuration/MovingOutCommonConfig.java
@@ -19,7 +19,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan(basePackageClasses = {MovingOutCommon.class})
 @EntityScan(basePackageClasses = {MovingOutCommon.class})
 @SpringBootConfiguration
-@ConfigurationPropertiesScan( basePackageClasses = {MovingOutCommon.class})
+@ConfigurationPropertiesScan( basePackages = {"com.suwon.toy"})
 @EnableAutoConfiguration
 @EnableJpaRepositories(
         basePackageClasses = {MovingOutCommon.class}

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/employee/Employee.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/employee/Employee.java
@@ -1,0 +1,54 @@
+/**
+ * ===============================================================
+ * File name : Employee.java
+ * Created by injeahwang on 2021-08-21
+ * ===============================================================
+ */
+package com.suwon.toy.moving.out.common.employee;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "TB_EMPLOYEE")
+@Getter
+@Setter
+@SequenceGenerator(
+        name="SEQ_EMPLOYEE_GEN",
+        sequenceName="EMPLOYEE_SEQ", //시퀀스 이름
+        initialValue=1, //시작값
+        allocationSize=1 //메모리를 통해 할당할 범위 사이즈
+)
+public class Employee {
+
+    @Id
+    @Column(name = "EMP_ID")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_EMPLOYEE_GEN")
+    private Long empId; // TODO : EMP_ID는 SEQUENCE를 이용해서 발번하는 PK인지 확인필요(Oracle은 SEQUENCE가 필수)
+
+    @Column(name="EMP_NAME")
+    private String empName;
+
+    @Column(name="PROFILE")
+    private String profile;
+
+    @Column(name = "TEAM_CD")
+    private String teamCd;
+
+    @Column(name="HIRE_DATE")
+    private LocalDateTime hireDate;
+
+    @Column(name="EMP_EMAIL")
+    private String empEmail;
+
+}

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/employee/EmployeeRepository.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/employee/EmployeeRepository.java
@@ -1,0 +1,12 @@
+/**
+ * ===============================================================
+ * File name : EmployeeRepository.java
+ * Created by injeahwang on 2021-08-21
+ * ===============================================================
+ */
+package com.suwon.toy.moving.out.common.employee;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+}

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/movinguser/MovingUserRepository.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/movinguser/MovingUserRepository.java
@@ -1,0 +1,14 @@
+/**
+ * ===============================================================
+ * File name : MovingUserRepository.java
+ * Created by injeahwang on 2021-08-21
+ * ===============================================================
+ */
+package com.suwon.toy.moving.out.common.movinguser;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MovingUserRepository extends JpaRepository<MovingUser, String> {
+}

--- a/moving-out-common/src/main/resources/application.yml
+++ b/moving-out-common/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   application:
-    name: moving-out-domain
+    name: moving-out-common
   config:
     activate:
       on-profile: default

--- a/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/MovingOutDomainApplicationTests.java
+++ b/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/MovingOutDomainApplicationTests.java
@@ -1,13 +1,15 @@
-//package com.suwon.toy.moving.out.domain;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//@SpringBootTest
-//class MovingOutDomainApplicationTests {
-//
-//    @Test
-//    void contextLoads() {
-//    }
-//
-//}
+package com.suwon.toy.moving.out.common;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MovingOutDomainApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/employee/EmployeeRepositoryTest.java
+++ b/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/employee/EmployeeRepositoryTest.java
@@ -1,0 +1,49 @@
+/**
+ * ===============================================================
+ * File name : EmployeeRepositoryTest.java
+ * Created by injeahwang on 2021-08-21
+ * ===============================================================
+ */
+package com.suwon.toy.moving.out.common.employee;
+
+import com.suwon.toy.moving.out.common.configuration.MovingOutCommonConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Repository;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class))
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.AUTO_CONFIGURED)
+@Import(MovingOutCommonConfig.class)
+public class EmployeeRepositoryTest {
+
+    @Autowired
+    EmployeeRepository employeeRepository;
+
+    @Test
+    @DisplayName("이사 센터 직원의 정보를 등록한다.")
+    public void movingEmployeeRegisterTest(){
+        Employee employee = new Employee();
+        employee.setEmpName("김철수");
+        employee.setProfile("profile");
+        employee.setHireDate(LocalDateTime.now());
+        employee.setEmpEmail("00000@gmail.com");
+        employee.setTeamCd("00"); // TODO : Team Code 체계??
+
+        assertDoesNotThrow(()->this.employeeRepository.save(employee));
+        assertEquals(employee.getEmpId(),
+                this.employeeRepository.findById(employee.getEmpId()).get().getEmpId());
+    }
+}

--- a/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/movinguser/MovingUserRepositoryTest.java
+++ b/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/movinguser/MovingUserRepositoryTest.java
@@ -1,0 +1,56 @@
+/**
+ * ===============================================================
+ * File name : MovingUserRepositoryTest.java
+ * Created by injeahwang on 2021-08-21
+ * ===============================================================
+ */
+package com.suwon.toy.moving.out.common.movinguser;
+
+
+import com.suwon.toy.moving.out.common.configuration.MovingOutCommonConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Repository;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class))
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.AUTO_CONFIGURED)
+@Import(MovingOutCommonConfig.class)
+public class MovingUserRepositoryTest {
+
+    @Autowired
+    MovingUserRepository movingUserRepository;
+
+    @Test
+    @DisplayName("이사 희망 고객을 DB에 등록한다.")
+    public void movingUserRegisterTest(){
+        MovingUser newMovingUser = new MovingUser();
+        newMovingUser.setUserId(UUID.randomUUID().toString()); // TODO : ID 발번 정책?
+        newMovingUser.setAddress("사랑시 고백구 행복동");
+        newMovingUser.setEmail("00000@gmail.com");
+        newMovingUser.setName("신짱구");
+        newMovingUser.setPhone("010-0000-0000");
+        newMovingUser.setPassword("1234"); // TODO : Password 암호화 전략 확인 필요.
+
+        assertDoesNotThrow(()->this.movingUserRepository.save(newMovingUser));
+        this.movingUserRepository.flush();
+
+        assertEquals(newMovingUser.getUserId(),
+                this.movingUserRepository.findById(newMovingUser.getUserId()).get().getUserId());
+    }
+
+}

--- a/moving-out-common/src/test/resources/application-test.yml
+++ b/moving-out-common/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: root
+    password: mysql
+    driverClassName: org.h2.Driver
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
* JPA Employee DB 연동 설정 추가
  * Employee 테이블에 Key 타입이 Number 인데, Sequence로 발번이 필요한 PK 인지 확인 필요합니다~ 
* common 공통 설정 보완 (1차적으로 완료하였습니다.)
  * gradle만 쓰다가 오랜만에 maven 가지고 프로젝트 설정 잡느라 삽질의 연속이었네요 ..ㅠㅠ
  * DB에 접근하는 CRUD 공통 기능은 common에 작성하도록 합니다.
  * 그 외 비즈니스 로직은 (Service 레이어) 각자 모듈에서 작성하도록 합니다
* 단위테스트 실패 시 mvn install 제약 기능 추가.
  * 기능 로직 구현 후, 단위 테스트를 꼼꼼히 작성하도록 합니다~ 
  * [https://sabarada.tistory.com/68](https://sabarada.tistory.com/68)
