### PR TITLE
[서버]-Swagger-ui 문서 적용 및 그에 따른 Yak Shaving...

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ docker-compose up -d
 docker-compose down -v
 ```
 
+---
+
 ## 인증 인가 기능 추가
 
 ### 프로그램 로딩 전 아래 쿼리 실행
@@ -124,3 +126,9 @@ public class TemporalAuthSetupRunner implements ApplicationRunner {
 3. 로그인 이후
 * GET / http://localhost:8080/api/user
 헤더에 Bearer 토큰으로 2.에서 응답받은 JWT 토큰을 요청에 넣어서 보낸다.
+
+---
+
+## Swagger-ui 
+
+* http://localhost:8080/swagger-ui/index.html

--- a/moving-out-api/pom.xml
+++ b/moving-out-api/pom.xml
@@ -13,7 +13,6 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>moving-out-api</name>
     <description>moving-out-api</description>
-    <packaging>jar</packaging>
 
     <properties>
         <java.version>11</java.version>
@@ -31,15 +30,17 @@
             <groupId>com.suwon.toy</groupId>
             <artifactId>moving-out-common</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>compile</scope>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>com.suwon.toy</groupId>-->
-<!--            <artifactId>moving-out-common</artifactId>-->
-<!--            <version>0.0.1-SNAPSHOT</version>-->
-<!--            <type>test-jar</type>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>com.suwon.toy</groupId>
+            <artifactId>moving-out-common</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -90,17 +91,28 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-testCompile</id>
+                        <phase>compile</phase>
                         <goals>
-                            <goal>test-jar</goal>
+                            <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-jar-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>test-jar</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/AuthController.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/AuthController.java
@@ -10,6 +10,11 @@ import com.suwon.toy.moving.out.api.auth.dto.LoginDto;
 import com.suwon.toy.moving.out.api.auth.dto.TokenDto;
 import com.suwon.toy.moving.out.api.auth.util.jwt.JwtFilter;
 import com.suwon.toy.moving.out.api.auth.util.jwt.TokenProvider;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.headers.Header;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +22,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -35,8 +37,10 @@ public class AuthController {
         this.authenticationManagerBuilder = authenticationManagerBuilder;
     }
 
+    @ApiOperation(value = "사용자 인증(로그인 처리)")
     @PostMapping("/authenticate")
-    public ResponseEntity<TokenDto> authorize(@Valid @RequestBody LoginDto loginDto) {
+    public ResponseEntity<TokenDto> authorize(
+            @Valid @RequestBody LoginDto loginDto) {
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginDto.getUserId(), loginDto.getPassword());
 

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/HelloController.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/HelloController.java
@@ -6,6 +6,9 @@
  */
 package com.suwon.toy.moving.out.api.auth.controller;
 
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,8 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class HelloController {
-	
 
+
+    @ApiOperation(value = "메인 용 테스트 API(명세가 확정되지 않음)")
     @GetMapping("/main")
     public ResponseEntity<String> hello() {
         return ResponseEntity.ok("main이 들어올 예정입니다.");

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/UserController.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/controller/UserController.java
@@ -12,6 +12,9 @@ import com.suwon.toy.moving.out.api.auth.service.MovingUserAuthService;
 import com.suwon.toy.moving.out.common.common.annotation.security.ApplyAdminRole;
 import com.suwon.toy.moving.out.common.common.annotation.security.ApplyUserAdminRole;
 import com.suwon.toy.moving.out.common.movinguser.MovingUser;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +36,7 @@ public class UserController {
         this.userService = userService;
     }
 
+    @ApiOperation(value = "신규 가입(계정 가입)")
     @PostMapping("/signup")
     public ResponseEntity<MovingUser> signup(
             @Valid @RequestBody UserDto userDto
@@ -40,12 +44,14 @@ public class UserController {
         return ResponseEntity.ok(userService.signup(userDto));
     }
 
+    @ApiOperation(value = "유저 정보 조회(로그인한 User)")
     @GetMapping("/user")
     @ApplyUserAdminRole
     public ResponseEntity<MovingUser> getMyUserInfo() {
         return ResponseEntity.ok(userService.getMyUserWithAuthorities().get());
     }
 
+    @ApiOperation(value = "UserId로 사용자 조회(Admin 전용)")
     @GetMapping("/user/{userId}")
     @ApplyAdminRole
     public ResponseEntity<MovingUser> getUserInfo(@PathVariable String userId) {

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/LoginDto.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/LoginDto.java
@@ -6,6 +6,8 @@
  */
 package com.suwon.toy.moving.out.api.auth.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,12 +20,15 @@ import javax.validation.constraints.Size;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description="login시 요청으로 받는 정보 입니다.")
 public class LoginDto {
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "jay1234")
     @NotNull
     @Size(min=3, max=100)
     private String userId;
 
+    @ApiModelProperty(name="password", notes = "가급적 hashing 된 값이 넘어왔으면 좋겠습니다.", required = true, dataType = "String", example = "1234")
     @NotNull
     private String password;
 }

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/TokenDto.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/TokenDto.java
@@ -6,6 +6,8 @@
  */
 package com.suwon.toy.moving.out.api.auth.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +17,9 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel
 public class TokenDto {
 
+    @ApiModelProperty(name="JWT Token", required = true, dataType = "String")
     private String token;
 }

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/UserDto.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/dto/UserDto.java
@@ -7,6 +7,8 @@
 package com.suwon.toy.moving.out.api.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,23 +21,29 @@ import javax.validation.constraints.Size;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description="sign-up(회원 가입)시 요청으로 받는 정보 입니다. - 인증 과정 전에 수행합니다.")
 public class UserDto {
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "jay1234")
     @NotNull
     @Size(min = 3, max = 50)
     private String userId;
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "1234")
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @NotNull
     @Size(min = 3, max = 100)
     private String password;
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "jayhwang")
     @NotNull
     @Size(min = 3, max = 50)
     private String username;
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "사랑시 고백구 행복동")
     private String address;
 
+    @ApiModelProperty(name="user-id", required = true, dataType = "String", example = "000-0000-0000")
     @NotNull
     private String phoneNumber;
 

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/service/MovingUserAuthService.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/auth/service/MovingUserAuthService.java
@@ -60,6 +60,7 @@ public class MovingUserAuthService {
 
     @Transactional(readOnly = true)
     public Optional<MovingUser> getMyUserWithAuthorities() {
+        // SecurityContext에서 User 정보를 받아 읽어온다.
         return SecurityUtil.getCurrentUsername().flatMap(userRepository::findOneWithAuthoritiesByUserId);
     }
 }

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/configuration/SecurityConfig.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/configuration/SecurityConfig.java
@@ -38,6 +38,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
     }
 
+    private static final String[] SWAGGER_AUTH_WHITELIST = {
+            "/swagger-resources/**",
+            "/swagger-ui/**",
+            "/v2/api-docs",
+            "/webjars/**"
+    };
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -48,7 +55,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring()
                 .antMatchers(
                         "/favicon.ico"
-                );
+                )
+                .antMatchers(SWAGGER_AUTH_WHITELIST);
     }
 
     @Override

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/employee/controller/EmployeeController.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/employee/controller/EmployeeController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import com.suwon.toy.moving.out.common.common.annotation.security.ApplyAdminRole;
 import com.suwon.toy.moving.out.common.common.annotation.security.ApplyUserAdminRole;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -31,13 +32,15 @@ public class EmployeeController {
 	public EmployeeController(EmployeeService employeeService) {
 		this.employeeService = employeeService;
 	}
-	
+
+	@ApiOperation(value = "직원 목록 조회(User, Admin 공통)")
 	@GetMapping("/employee/list")
 	@ApplyUserAdminRole
     public ResponseEntity<List<Employee>> getEmployeeInfoList(){
 		return ResponseEntity.ok(employeeService.getEmployeeInfoList());
 	}
-	
+
+	@ApiOperation(value = "직원 성명으로 조회(User, Admin 공통)")
 	@GetMapping("/employee/{empName}")
 	@ApplyUserAdminRole
 	public ResponseEntity<List<Employee>> getEmployeeInfo(@PathVariable String empName){
@@ -45,6 +48,7 @@ public class EmployeeController {
 		return ResponseEntity.ok(employeeService.getEmployeeInfo(empName,pageable));
 	}
 
+	@ApiOperation(value = "직원 등록(Admin 전용)")
 	@PostMapping("/employee/insert")
     @ApplyAdminRole
 	public ResponseEntity<Employee> insertEmployee(@Valid @RequestBody Employee employeeDto){

--- a/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/healthcheck/PingController.java
+++ b/moving-out-api/src/main/java/com/suwon/toy/moving/out/api/healthcheck/PingController.java
@@ -7,6 +7,7 @@
 package com.suwon.toy.moving.out.api.healthcheck;
 
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 @RestController
 public class PingController {
 
+    @ApiOperation(value = "Health 체크 용 API(moving-out-api)")
     @GetMapping("/api/ping")
     public Map<String,String> pingpong(){
         Map<String, String> msg = new HashMap<>();

--- a/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/auth/TokenExceptionTest.java
+++ b/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/auth/TokenExceptionTest.java
@@ -11,6 +11,7 @@ import com.suwon.toy.moving.out.api.auth.dto.TokenDto;
 import com.suwon.toy.moving.out.api.auth.dto.UserDto;
 import com.suwon.toy.moving.out.api.auth.service.MovingUserAuthService;
 import com.suwon.toy.moving.out.api.auth.util.jwt.TokenProvider;
+import com.suwon.toy.moving.out.common.configuration.EnableMockMvc;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@EnableMockMvc
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TokenExceptionTest {
@@ -77,7 +78,7 @@ public class TokenExceptionTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json"))
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.token").exists());
 
         String str = result.andReturn().getResponse().getContentAsString();
@@ -110,7 +111,7 @@ public class TokenExceptionTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json"))
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.token").exists());
 
         String str = result.andReturn().getResponse().getContentAsString();

--- a/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/auth/UserControllerTest.java
+++ b/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/auth/UserControllerTest.java
@@ -7,16 +7,11 @@
 package com.suwon.toy.moving.out.api.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.suwon.toy.moving.out.api.auth.dto.TokenDto;
+import com.suwon.toy.moving.out.common.configuration.EnableMockMvc;
 import com.suwon.toy.moving.out.common.movinguser.MovingUser;
 import com.suwon.toy.moving.out.common.movinguser.MovingUserRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -28,10 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@EnableMockMvc
 @ActiveProfiles("test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class UserControllerTest {
@@ -54,7 +50,7 @@ public class UserControllerTest {
                                 "\t\"userId\":\"test1\",\n" +
                                 "\t\"password\":\"1234\",\n" +
                                 "\t\"username\":\"jay\",\n" +
-                                "\t\"address\":null,\n" +
+                                "\t\"address\":\"사랑시 고백구 행복동\",\n" +
                                 "\t\"phoneNumber\":\"010000000\"\n" +
                                 "}")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -71,10 +67,11 @@ public class UserControllerTest {
     @Order(2)
     @Test
     @DisplayName("인증된 유저에 대한 유저 정보가 조회 되어야 합니다.")
-    @WithMockUser(username = "test1", roles={"USER"})
+    @WithMockUser(username = "test1", roles="USER")
     public void getMyUserInfo_success() throws Exception {
         mockMvc.perform(get("/api/user")).andDo(print())
                 .andExpect(status().isOk());
+//                .andExpect();
     }
 
     @Order(3)

--- a/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/employee/EmployeeControllerTest.java
+++ b/moving-out-api/src/test/java/com/suwon/toy/moving/out/api/employee/EmployeeControllerTest.java
@@ -6,24 +6,17 @@
  */
 package com.suwon.toy.moving.out.api.employee;
 
-import com.suwon.toy.moving.out.api.configuration.SecurityConfig;
-import com.suwon.toy.moving.out.api.employee.controller.EmployeeController;
 import com.suwon.toy.moving.out.api.employee.service.EmployeeService;
+import com.suwon.toy.moving.out.common.configuration.EnableMockMvc;
 import com.suwon.toy.moving.out.common.employee.Employee;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -38,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@EnableMockMvc
 @ActiveProfiles("test")
 public class EmployeeControllerTest {
 
@@ -69,7 +62,7 @@ public class EmployeeControllerTest {
 
         mockMvc.perform(get("/api/employee/list")).andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json"));
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
     }
 
     @Test
@@ -80,7 +73,7 @@ public class EmployeeControllerTest {
 
         mockMvc.perform(get("/api/employee/anyone")).andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json"));
+                .andExpect(content().contentType("application/json;charset=UTF-8"));
     }
 
     @Test

--- a/moving-out-common/pom.xml
+++ b/moving-out-common/pom.xml
@@ -14,99 +14,9 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+
     <name>moving-out-common</name>
     <description>moving-out-common</description>
-
-<!--    <properties>-->
-<!--        <java.version>11</java.version>-->
-<!--        <maven.compiler.target>11</maven.compiler.target>-->
-<!--        <maven.compiler.source>11</maven.compiler.source>-->
-
-<!--        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>-->
-<!--        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>-->
-<!--        <spring-boot.version>2.5.4</spring-boot.version>-->
-<!--    </properties>-->
-
-<!--    <dependencies>-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-starter-data-jpa</artifactId>-->
-<!--        </dependency>-->
-
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-configuration-processor</artifactId>-->
-<!--        </dependency>-->
-
-<!--        <dependency>-->
-<!--            <groupId>com.oracle.database.jdbc</groupId>-->
-<!--            <artifactId>ojdbc8</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.projectlombok</groupId>-->
-<!--            <artifactId>lombok</artifactId>-->
-<!--            <optional>true</optional>-->
-<!--        </dependency>-->
-
-<!--        <dependency>-->
-<!--            <groupId>org.springframework.boot</groupId>-->
-<!--            <artifactId>spring-boot-starter-test</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-
-<!--        <dependency>-->
-<!--            <groupId>com.h2database</groupId>-->
-<!--            <artifactId>h2</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--    </dependencies>-->
-
-<!--    <build>-->
-<!--        <plugins>-->
-<!--            <plugin>-->
-<!--                &lt;!&ndash; 단위 테스트 실패 시, maven install에 제약을 거는 설정입니다.-->
-<!--                    https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html-->
-<!--                 &ndash;&gt;-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>3.0.0-M5</version>-->
-<!--                <configuration>-->
-<!--                    <testFailureIgnore>false</testFailureIgnore>-->
-<!--                    <includes>-->
-<!--                        <include>**/*Test*.java</include>-->
-<!--                    </includes>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <phase>clean</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>test</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--                <dependencies>-->
-<!--                    <dependency>-->
-<!--                        <groupId>org.junit.jupiter</groupId>-->
-<!--                        <artifactId>junit-jupiter-engine</artifactId>-->
-<!--                        <version>5.3.2</version>-->
-<!--                    </dependency>-->
-<!--                </dependencies>-->
-<!--            </plugin>-->
-
-<!--            <plugin>-->
-<!--                <groupId>org.springframework.boot</groupId>-->
-<!--                <artifactId>spring-boot-maven-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <excludes>-->
-<!--                        <exclude>-->
-<!--                            <groupId>org.projectlombok</groupId>-->
-<!--                            <artifactId>lombok</artifactId>-->
-<!--                        </exclude>-->
-<!--                    </excludes>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
-<!--        </plugins>-->
-<!--    </build>-->
 
     <dependencyManagement>
         <dependencies>
@@ -119,5 +29,38 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <!--
+            왜 자꾸 moving-out-api에서 common test-jar를 못찾아서 빌드 fail이 발생하는지 원인은 못찾았지만, 아래 솔류션을 적용하니 해결이 된 것 같습니다.
+            향후에도 비슷한 문제가 발생할 때 참고하고자 링크 남겨놉니다.
+            https://stackoverflow.com/questions/4786881/why-is-test-jar-dependency-required-for-mvn-compile'
+            -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/configuration/SpringFoxSwaggerConfig.java
+++ b/moving-out-common/src/main/java/com/suwon/toy/moving/out/common/configuration/SpringFoxSwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.suwon.toy.moving.out.common.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+// TODO : Profile로 local / dev 이외 Production에서 노출되지 않도록 함.
+public class SpringFoxSwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.suwon.toy.moving.out"))
+                .paths(PathSelectors.any())
+                .build()
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()));
+    }
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("Authorization", "Authorization", "header");
+    }
+
+}

--- a/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/configuration/EnableMockMvc.java
+++ b/moving-out-common/src/test/java/com/suwon/toy/moving/out/common/configuration/EnableMockMvc.java
@@ -1,0 +1,26 @@
+package com.suwon.toy.moving.out.common.configuration;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.annotation.*;
+
+// MockMvc에서 한글 깨짐 현상이 발생
+// https://pompitzz.github.io/blog/Spring/MockMvc_Encoding.html#%E1%84%92%E1%85%A2%E1%84%80%E1%85%A7%E1%86%AF%E1%84%87%E1%85%A5%E1%86%B8
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AutoConfigureMockMvc
+@Import(EnableMockMvc.MockMvcTestConfig.class)
+public @interface EnableMockMvc {
+    class MockMvcTestConfig {
+        @Bean
+        @Primary
+        public CharacterEncodingFilter characterEncodingFilter() {
+            return new CharacterEncodingFilter("UTF-8", true);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,20 @@
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
         </dependency>
+
+        <!-- for Swagger -->
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <!-- for Swagger -->
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
* swagger-ui 적용
  * moving-out-api 서버 실행 후 README.md 참고해주세요  
* MockMvc에 response에 한글 깨짐 현상 조치
  * Spring boot 2.2.X 이후부터 ```MediaType.APPLICATION_JSON_UTF_8``` 미디어 타입 지원 중단으로 인한 사이드이펙트로 추정됩니다.
  * 참고 : https://jehuipark.github.io/spring/boot-2-2-x-mock-mvc-encoding-issue
  * 참고 : https://pompitzz.github.io/blog/Spring/MockMvc_Encoding.html
  * common-test에 ```CharacterEncodingFilter```를 커스터마이징한 Bean을 등록
  * 컨트롤러 테스트 작성시 ```@AutoConfigureMockMvc``` 어노테이션 대신 ```@EnableMockMvc```를 사용해주세요
* maven에서 test-jar 의존성을 찾지 못해 빌드 fail이 뜨는 문제 조치..
  *  ```@EnableMockMvc``` 커스텀 어노테이션을 common-test의 ApplicationContext에 등록해서 사용하려고 테스트 패키지에 적용을 했는데..
  * 문제는 api에서 common-test의 모듈을 불러오고자 하니 maven에서 test-jar 디펜던시를 인식하지 못하는 문제가 발생 
  * 원인은 찾지 못했습니다.
  * 솔루션(두번째 답변) : https://stackoverflow.com/questions/4786881/why-is-test-jar-dependency-required-for-mvn-compile
  * plugin 변경해서 적용해보니 해결이 된 것으로 보입니다. 